### PR TITLE
Landing page with tryouts info and CTA

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -369,6 +369,22 @@ h4 { font-size: var(--font-size-lg); }
   color: var(--color-gray-400);
 }
 
+/* --- Details List --- */
+.details-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.details-list li {
+  color: var(--color-gray-400);
+}
+
+.details-list strong {
+  color: var(--color-gray-100);
+}
+
 /* --- FAQ --- */
 .faq-item {
   padding: var(--space-lg) 0;

--- a/index.html
+++ b/index.html
@@ -36,7 +36,131 @@
     </div>
   </section>
 
-  <!-- Content sections will be added in Issue #2 -->
+  <!-- About -->
+  <section id="about" class="section">
+    <div class="container">
+      <div class="section-header">
+        <h2>About the Program</h2>
+        <p>West Side Basketball develops competitive youth players through high-level coaching, structured practices, and AAU tournament play.</p>
+      </div>
+      <div class="grid grid-3">
+        <div class="card">
+          <h3>Skill Development</h3>
+          <p>Focused training on fundamentals — ball handling, shooting mechanics, defensive footwork, and basketball IQ. Every player gets better.</p>
+        </div>
+        <div class="card">
+          <h3>Competitive Play</h3>
+          <p>AAU tournament competition against top programs in Utah and the region. Real games, real pressure, real growth.</p>
+        </div>
+        <div class="card">
+          <h3>Next-Level Prep</h3>
+          <p>Preparing players for high school varsity and beyond. We build the habits, discipline, and confidence that translate to the next stage.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Tryouts Details -->
+  <section id="tryouts" class="section section-alt">
+    <div class="container">
+      <div class="section-header">
+        <h2>Tryouts Information</h2>
+        <p>Open to all skill levels. Come ready to compete.</p>
+      </div>
+      <div class="grid grid-2">
+        <div class="card">
+          <h3>Details</h3>
+          <ul class="details-list">
+            <li><strong>Dates:</strong> TBD</li>
+            <li><strong>Time:</strong> TBD</li>
+            <li><strong>Location:</strong> Near Cyprus High School, West Jordan, UT</li>
+            <li><strong>Ages:</strong> Youth &amp; Middle School</li>
+            <li><strong>Cost:</strong> TBD</li>
+          </ul>
+        </div>
+        <div class="card">
+          <h3>What to Bring</h3>
+          <ul class="details-list">
+            <li>Basketball shoes (court shoes required)</li>
+            <li>Athletic shorts and shirt</li>
+            <li>Water bottle</li>
+            <li>Positive attitude and willingness to compete</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- How It Works -->
+  <section class="section">
+    <div class="container">
+      <div class="section-header">
+        <h2>How It Works</h2>
+        <p>Three simple steps to join the team.</p>
+      </div>
+      <div class="grid grid-3">
+        <div class="step">
+          <div class="step-number">1</div>
+          <h3>Register Online</h3>
+          <p>Sign up and pay the tryout fee through our secure online registration. Parent/guardian info and player details collected at checkout.</p>
+        </div>
+        <div class="step">
+          <div class="step-number">2</div>
+          <h3>Attend Tryouts</h3>
+          <p>Show up ready to play. Coaches evaluate skills, basketball IQ, coachability, and hustle. All positions and skill levels welcome.</p>
+        </div>
+        <div class="step">
+          <div class="step-number">3</div>
+          <h3>Get Placed on a Team</h3>
+          <p>Players are placed on teams based on age, skill level, and tryout performance. Season details and schedules follow shortly after.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- FAQ -->
+  <section id="faq" class="section section-alt">
+    <div class="container">
+      <div class="section-header">
+        <h2>Frequently Asked Questions</h2>
+      </div>
+      <div class="faq-list">
+        <div class="faq-item">
+          <h3>What age groups do you offer?</h3>
+          <p>We offer teams for youth and middle school players. Specific age divisions will be determined based on registration numbers and tryout results.</p>
+        </div>
+        <div class="faq-item">
+          <h3>Does my child need prior AAU experience?</h3>
+          <p>No. Tryouts are open to all skill levels. We evaluate effort, coachability, and potential — not just current ability.</p>
+        </div>
+        <div class="faq-item">
+          <h3>What is the time commitment?</h3>
+          <p>Teams typically practice 2–3 times per week with tournaments on weekends during the AAU season. A full schedule is provided after team placement.</p>
+        </div>
+        <div class="faq-item">
+          <h3>What does the tryout fee cover?</h3>
+          <p>The tryout fee covers the evaluation session. Season fees (covering coaching, gym time, tournament entry, and uniforms) are separate and communicated after team placement.</p>
+        </div>
+        <div class="faq-item">
+          <h3>What if my child doesn't make a team?</h3>
+          <p>We aim to place every player who tries out. If we can't offer a spot, we'll provide feedback and recommendations for development.</p>
+        </div>
+        <div class="faq-item">
+          <h3>Who are the coaches?</h3>
+          <p>Our program is led by Marcus Draney, an experienced coach with a passion for player development. <a href="coaches.html">Learn more about our coaching staff.</a></p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Bottom CTA -->
+  <section class="cta-banner">
+    <div class="container">
+      <h2>Ready to Take Your Game to the Next Level?</h2>
+      <p>Spots are limited. Register today to secure your tryout.</p>
+      <a href="#" class="btn btn-primary btn-lg">Sign Up for Tryouts</a>
+    </div>
+  </section>
 
   <!-- Footer -->
   <footer class="site-footer">


### PR DESCRIPTION
## Summary

- Full landing page content: hero, about (3 cards), tryouts details, how-it-works (3 steps), FAQ (6 items), bottom CTA
- CTA buttons link to `#` (Stripe Payment Link added in #4)
- Tryout details use placeholder content (dates, cost, ages TBD — user to provide)
- Added `.details-list` CSS for structured info display in cards

Closes #2

## Test plan

- [ ] Open index.html — all sections render: hero, about, tryouts, how-it-works, FAQ, bottom CTA
- [ ] Mobile responsive — cards stack vertically, text readable
- [ ] Desktop — cards in 2/3 column grids
- [ ] All anchor links (#about, #tryouts, #faq) scroll to correct sections
- [ ] CTA buttons present (href="#" for now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)