### PR TITLE
Coaches page (Marcus Draney)

### DIFF
--- a/coaches.html
+++ b/coaches.html
@@ -41,11 +41,11 @@
 
       <!-- Marcus Draney -->
       <article class="coach-card card">
-        <div class="coach-photo" aria-label="Photo of Marcus Draney">
-          Photo coming soon
-        </div>
+        <figure class="coach-photo">
+          <figcaption>Photo coming soon</figcaption>
+        </figure>
         <div class="coach-info">
-          <h3>Marcus Draney</h3>
+          <h2>Marcus Draney</h2>
           <p class="coach-role">Head Coach &amp; Program Director</p>
           <p>Marcus Draney is the founder and head coach of West Side Basketball. Based in West Jordan, Utah, Marcus brings a deep passion for the game and a commitment to developing young athletes both on and off the court.</p>
           <p>With experience coaching at the youth and AAU levels, Marcus focuses on building strong fundamentals, basketball IQ, and the competitive mindset players need to succeed at the next level.</p>

--- a/css/style.css
+++ b/css/style.css
@@ -410,6 +410,7 @@ h4 { font-size: var(--font-size-lg); }
   font-size: var(--font-size-sm);
 }
 
+.coach-info h2,
 .coach-info h3 {
   font-size: var(--font-size-2xl);
   margin-bottom: var(--space-xs);


### PR DESCRIPTION
## Summary

- Coaches page with hero and reusable coach-card article pattern
- Marcus Draney profile: head coach, placeholder bio and photo
- CTA banner linking to tryouts info
- Structure accommodates adding more coaches later (just duplicate the coach-card article)

Closes #6

## Test plan

- [ ] Open coaches.html — hero, Marcus card, CTA banner render
- [ ] Mobile — photo stacks above bio text
- [ ] Desktop/tablet — photo and bio side-by-side
- [ ] Nav links point to index.html sections correctly
- [ ] "View Tryouts Info" CTA links to index.html#tryouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)