### PR TITLE
Add coach: KJ Ng

### DIFF
--- a/coaches.html
+++ b/coaches.html
@@ -65,7 +65,7 @@
 
   <!-- Coaches -->
   <section class="section">
-    <div class="container">
+    <div class="container coaches-list">
 
       <!-- Marcus Draney -->
       <article class="coach-card card">
@@ -82,7 +82,19 @@
         </div>
       </article>
 
-      <!-- Additional coaches can be added here using the same coach-card pattern -->
+      <!-- KJ Ng -->
+      <article class="coach-card card">
+        <figure class="coach-photo">
+          <div class="coach-photo-placeholder">Photo coming soon</div>
+        </figure>
+        <div class="coach-info">
+          <h2>KJ Ng</h2>
+          <p class="coach-role">Coach</p>
+          <p>KJ Ng played high school basketball in Hawaii before earning a spot on the roster at the University of Providence, where he competed at the college level. After his playing career, KJ transitioned to the coaching staff for one season, gaining firsthand experience in player development and program building.</p>
+          <p>KJ also represented the Hawaii National team in international exhibition play, competing against top talent on a global stage.</p>
+          <p>Currently, KJ serves as the head coach of Hunter High School boys basketball, where he brings the same competitive intensity and commitment to developing young athletes that defines Westside Kings &amp; Queens.</p>
+        </div>
+      </article>
 
     </div>
   </section>

--- a/css/style.css
+++ b/css/style.css
@@ -502,6 +502,13 @@ h4 { font-size: var(--font-size-lg); }
   color: var(--color-gray-400);
 }
 
+/* --- Coaches List --- */
+.coaches-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2xl);
+}
+
 /* --- Coach Card --- */
 .coach-card {
   display: flex;
@@ -521,6 +528,18 @@ h4 { font-size: var(--font-size-lg); }
 .coach-photo img {
   width: 100%;
   height: auto;
+}
+
+.coach-photo-placeholder {
+  width: 100%;
+  aspect-ratio: 2 / 3;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-gray-600);
+  font-size: var(--font-size-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
 
 .coach-info h2,


### PR DESCRIPTION
## Summary

- Add KJ Ng to the coaches page with full bio
- Hawaii HS basketball → University of Providence → coaching staff → Hawaii National team → Hunter HS head coach
- Photo placeholder (no photo yet)
- Added `.coaches-list` wrapper for proper spacing between multiple coach cards

Closes #18

## Test plan

- [ ] KJ Ng card appears below Marcus on coaches page
- [ ] Placeholder photo area displays "Photo coming soon"
- [ ] Bio reads accurately
- [ ] Mobile responsive — cards stack vertically
- [ ] Spacing between coach cards looks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)