### PR TITLE
Content fixes: remove Umpqua, generalize tournament fees

### DIFF
--- a/coaches.html
+++ b/coaches.html
@@ -76,7 +76,7 @@
           <h2>Marcus Draney</h2>
           <p class="coach-role">Head Coach &amp; Program Director</p>
           <p>Marcus Draney is the founder and head coach of Westside Kings &amp; Queens. With 9 years of AAU basketball experience, Marcus brings a proven track record of developing young athletes both on and off the court.</p>
-          <p>A four-year varsity starting combo guard, Marcus was named to the Utah All-State basketball team twice, earned All-Region honors three years, and All-County three years. He played collegiately at Umpqua Community College on a basketball scholarship.</p>
+          <p>A four-year varsity starting combo guard, Marcus was named to the Utah All-State basketball team twice, earned All-Region honors three years, and All-County three years. He played college basketball on a scholarship.</p>
           <p>Most recently, Marcus served as Program Director, Coach, and Trainer at Club Utah/Invictus Basketball Academy (2020–2025), where he managed basketball program personnel, organized youth camps, and trained young athletes on strategy, tactics, and skills. He also runs MD4 Athletic Training, providing individual coaching and skills development.</p>
           <p>Marcus's coaching philosophy centers on accountability, toughness, and confidence — building leaders on and off the floor who compete with discipline and carry themselves to the highest standard.</p>
         </div>

--- a/index.html
+++ b/index.html
@@ -174,11 +174,11 @@
         </div>
         <div class="faq-item">
           <h3>What does the $200/month cover?</h3>
-          <p>The monthly investment covers coaching, gym time, and skill development sessions. Tournament fees are split between players on the team (approximately $55 per player per tournament). Jerseys are separate.</p>
+          <p>The monthly investment covers coaching, gym time, and skill development sessions. Tournament fees are split between players on the team and vary by event. Jerseys are separate.</p>
         </div>
         <div class="faq-item">
           <h3>What about tournament fees?</h3>
-          <p>Tournament entry fees are split evenly among the players on each team. For example, a $500 tournament fee split between 9 players comes out to about $55 per kid.</p>
+          <p>Tournament entry fees are split evenly among the players on each team. Costs vary by tournament, and you'll be notified of fees ahead of each event.</p>
         </div>
         <div class="faq-item">
           <h3>What if my child doesn't make a team?</h3>


### PR DESCRIPTION
## Summary

- Remove "Umpqua Community College" from Marcus bio — now says "played college basketball on a scholarship"
- Remove specific tournament fee amounts ($55/kid, $500 example) — now says fees "vary by event" with advance notification
- No changes needed for Stripe address collection (already handled on backend)

Closes #20

## Test plan

- [ ] Marcus bio on coaches.html no longer mentions Umpqua
- [ ] FAQ tournament fee answers have no specific dollar amounts
- [ ] $200/month FAQ still mentions tournament fees are split between players

🤖 Generated with [Claude Code](https://claude.com/claude-code)