### PR TITLE
Switch Stripe payment link from test to live

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
       <p class="hero-tagline">Adidas Sponsored &bull; West Valley, Utah</p>
       <h1>Westside Kings &amp; Queens</h1>
       <p class="hero-subtitle">This isn't babysitting. This isn't random open gym runs. This is structured development, culture, and competitive basketball done the right way.</p>
-      <a href="https://buy.stripe.com/test_bJe28s8Mj4pH8wc7iT6wE01" class="btn btn-primary btn-lg">Sign Up for Tryouts — $30</a>
+      <a href="https://buy.stripe.com/aFa8wRbky5KwgL0bI60VO01" class="btn btn-primary btn-lg">Sign Up for Tryouts — $30</a>
     </div>
   </section>
 
@@ -197,7 +197,7 @@
     <div class="container">
       <h2>Ready to Compete?</h2>
       <p>Tryouts are mid-March. Spots are limited. Register today.</p>
-      <a href="https://buy.stripe.com/test_bJe28s8Mj4pH8wc7iT6wE01" class="btn btn-primary btn-lg">Sign Up for Tryouts — $30</a>
+      <a href="https://buy.stripe.com/aFa8wRbky5KwgL0bI60VO01" class="btn btn-primary btn-lg">Sign Up for Tryouts — $30</a>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- Replaces sandbox Stripe Payment Link (`buy.stripe.com/test_...`) with live production link in both CTA buttons
- Live product, price ($30), and payment link created via Stripe API with identical configuration: player name, player height, graduating class custom fields, billing address collection, phone number collection, and success page redirect

Closes #22

## Test plan
- [ ] Visit the live payment link URL directly and confirm the checkout page loads with correct product name, price, and custom fields
- [ ] Click "Sign Up for Tryouts" in the hero section — verify it goes to the live Stripe checkout
- [ ] Click "Sign Up for Tryouts" in the bottom CTA — verify same live link
- [ ] Complete a test payment with a real card and confirm redirect to success.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)