### PR TITLE
Add Pal-E powered-by credit to success page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -607,6 +607,12 @@ h4 { font-size: var(--font-size-lg); }
   color: var(--color-red);
 }
 
+.powered-by {
+  margin-top: var(--space-md);
+  font-size: 0.75rem;
+  opacity: 0.6;
+}
+
 /* --- CTA Banner --- */
 .cta-banner {
   text-align: center;

--- a/success.html
+++ b/success.html
@@ -110,6 +110,7 @@
     <div class="container footer-inner">
       <p>Contact: <a href="tel:+13854509963">(385) 450-9963</a> &bull; <a href="mailto:marcusdraney23@gmail.com">marcusdraney23@gmail.com</a></p>
       <p>&copy; 2026 Westside Kings &amp; Queens. All rights reserved. &bull; Sponsored by Adidas</p>
+      <p class="powered-by">Registration powered by <a href="https://ldraney.github.io/pal-e/" target="_blank" rel="noopener">Pal-E</a> — AI-powered automation for sports programs, small businesses, and more.</p>
     </div>
   </footer>
 


### PR DESCRIPTION
## Summary
- Adds a subtle "Registration powered by Pal-E" credit line to the success page footer
- Links to https://ldraney.github.io/pal-e/
- Styled small and low-opacity so it doesn't compete with the main content
- Gives context for the "Pal-E" name on Stripe receipts and promotes the automation service

Closes #31

## Test plan
- [ ] Verify credit appears at bottom of success page
- [ ] Verify link opens Pal-E site in new tab
- [ ] Confirm it's subtle and doesn't distract from the registration confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)