### PR TITLE
Switch payment link back to $30

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
       <p class="hero-tagline">Adidas Sponsored &bull; West Valley, Utah</p>
       <h1>Westside Kings &amp; Queens</h1>
       <p class="hero-subtitle">This isn't babysitting. This isn't random open gym runs. This is structured development, culture, and competitive basketball done the right way.</p>
-      <a href="https://buy.stripe.com/28E14pbky4GscuK3bA0VO02" class="btn btn-primary btn-lg">Sign Up for Tryouts — $30</a>
+      <a href="https://buy.stripe.com/aFa8wRbky5KwgL0bI60VO01" class="btn btn-primary btn-lg">Sign Up for Tryouts — $30</a>
     </div>
   </section>
 
@@ -197,7 +197,7 @@
     <div class="container">
       <h2>Ready to Compete?</h2>
       <p>Tryouts are mid-March. Spots are limited. Register today.</p>
-      <a href="https://buy.stripe.com/28E14pbky4GscuK3bA0VO02" class="btn btn-primary btn-lg">Sign Up for Tryouts — $30</a>
+      <a href="https://buy.stripe.com/aFa8wRbky5KwgL0bI60VO01" class="btn btn-primary btn-lg">Sign Up for Tryouts — $30</a>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- Swaps the $1 test payment link back to the $30 live production link
- Both CTA buttons updated

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)