### PR TITLE
Add Abbie Sa to coaches page

### DIFF
--- a/coaches.html
+++ b/coaches.html
@@ -74,6 +74,19 @@
         </div>
       </article>
 
+      <!-- Abbie Sa -->
+      <article class="coach-card card">
+        <figure class="coach-photo">
+          <figcaption>Photo coming soon</figcaption>
+        </figure>
+        <div class="coach-info">
+          <h2>Abbie Sa</h2>
+          <p class="coach-role">Coach</p>
+          <p>Abbie Sa played basketball at Cyprus High School from 2010–2014. After attending Utah Tech for one year, she began coaching girls high school basketball. She coached at Cyprus High from 2016–2021, and after taking a break to grow her family, she started coaching 5th–8th grade girls in the Magna community on a Bantam team. She is currently coaching at Cyprus High School again.</p>
+          <p>Abbie has a deep love for the Magna community and girls basketball. She hopes to always impact players in a positive way and motivate them to become better in all aspects of life and basketball. She can't wait to start coaching in the AAU world.</p>
+        </div>
+      </article>
+
       <!-- Additional coaches can be added here using the same coach-card pattern -->
 
     </div>


### PR DESCRIPTION
## Summary

- Adds Abbie Sa's coach bio to `coaches.html` following the existing coach-card pattern
- Includes her basketball background (Cyprus High School player & coach, Bantam team, Utah Tech)
- Uses placeholder photo (same as Marcus's card) — can be updated when a headshot is provided

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)