### PR TITLE
Add Stripe promo code support for girls discount

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
     <div class="container">
       <h1>West Side Basketball</h1>
       <p class="hero-subtitle">Competitive AAU basketball development in West Jordan, Utah. Build your game. Join the team.</p>
-      <a href="https://buy.stripe.com/test_bJe28s8Mj4pH8wc7iT6wE01" class="btn btn-primary btn-lg">Sign Up for Tryouts</a>
+      <a href="https://buy.stripe.com/eVqaEZdsGgpa52i5jI0VO03" class="btn btn-primary btn-lg">Sign Up for Tryouts</a>
     </div>
   </section>
 
@@ -179,7 +179,7 @@
     <div class="container">
       <h2>Ready to Take Your Game to the Next Level?</h2>
       <p>Spots are limited. Register today to secure your tryout.</p>
-      <a href="https://buy.stripe.com/test_bJe28s8Mj4pH8wc7iT6wE01" class="btn btn-primary btn-lg">Sign Up for Tryouts</a>
+      <a href="https://buy.stripe.com/eVqaEZdsGgpa52i5jI0VO03" class="btn btn-primary btn-lg">Sign Up for Tryouts</a>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary

- Switches `index.html` from the test-mode Stripe link to the new **live $200 payment link** with promotion codes enabled
- Created Stripe resources (all live):
  - **Price**: `price_1T2OkbR9SdzWqVXMiabvH2kn` ($200.00)
  - **Payment Link**: `plink_1T2OkrR9SdzWqVXMT4jLhNAF` with `allow_promotion_codes: true`
  - **Coupon**: `u5nGTGkA` (20% off, one-time)
  - **Promo Code**: `GIRLSHOOPS` → pays $160 instead of $200

## Test plan

- [ ] Visit the live site and click "Sign Up for Tryouts" — should go to live Stripe checkout at $200
- [ ] Enter promo code `GIRLSHOOPS` at checkout — price should drop to $160
- [ ] Complete a test purchase and verify redirect to success page
- [ ] Verify the old test-mode link is no longer referenced

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)