### PR TITLE
EMERGENCY: Remove exposed credential from sponsors page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -480,7 +480,6 @@ h4 { font-size: var(--font-size-lg); }
   margin-bottom: var(--space-md);
 }
 
-
 .sponsor-card .btn {
   align-self: flex-start;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -480,22 +480,6 @@ h4 { font-size: var(--font-size-lg); }
   margin-bottom: var(--space-md);
 }
 
-.sponsor-coupon {
-  color: var(--color-red) !important;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
-  font-size: var(--font-size-sm);
-}
-
-.sponsor-coupon strong {
-  color: var(--color-white);
-  background-color: var(--color-gray-800);
-  padding: var(--space-xs) var(--space-sm);
-  border-radius: var(--border-radius);
-  font-family: monospace;
-  letter-spacing: 0.05em;
-}
 
 .sponsor-card .btn {
   align-self: flex-start;

--- a/sponsors.html
+++ b/sponsors.html
@@ -71,7 +71,6 @@
           <div class="sponsor-info">
             <h3>Snoopy THA Barber</h3>
             <p>Clean cuts, professional service. Proudly supporting Westside Kings &amp; Queens athletes.</p>
-            <p class="sponsor-coupon">Use code <strong>Ymcayouth4!</strong> for a discount</p>
             <span class="btn btn-outline">Book an Appointment</span>
           </div>
         </a>


### PR DESCRIPTION
## Summary
- **The barber "discount code" on sponsors.html is actually a password** — it was publicly visible on the live site
- Removes the `<p class="sponsor-coupon">` line containing the credential
- Removes the `.sponsor-coupon` CSS styles (no longer needed)

## Changes
- `sponsors.html`: Removed the coupon/discount code display line from the Snoopy THA Barber sponsor card
- `css/style.css`: Removed `.sponsor-coupon` and `.sponsor-coupon strong` CSS rules

## Test Plan
- [ ] Sponsors page loads without errors
- [ ] Snoopy THA Barber card still displays correctly (name, description, booking button)
- [ ] No credential visible anywhere on the page

## Review Checklist
- [ ] Passed automated review-fix loop
- [ ] No secrets committed
- [ ] No unnecessary file changes
- [ ] Commit messages reference issue numbers

## Linked Issues
Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)